### PR TITLE
Implemented `niri-ipc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This project uses Rust workspaces to maintain modularity and reusability:
 
 ### Phase 1: Backend Foundation
 - [x] Setup workspace structure
-- [ ] Create basic module skeleton
-- [ ] Implement `niri-ipc` for command execution
-- [ ] Test communication with Niri
+- [x] Create basic module skeleton
+- [x] Implement `niri-ipc` for command execution
+- [x] Test communication with Niri
 
 ### Phase 2: Monitor Configuration
 - [ ] Parse `niri msg outputs` in `niri-monitor`

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1,14 +1,53 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use std::process::Command;
+
+pub trait CommandExecutor {
+    fn execute(&self, program: &str, args: &[&str]) -> Result<String, String>;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub struct SystemCommandExecutor;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl CommandExecutor for SystemCommandExecutor {
+    fn execute(&self, program: &str, args: &[&str]) -> Result<String, String> {
+        let mut cmd = Command::new("niri");
+
+        cmd.args(args);
+
+        let output = cmd
+            .output()
+            .map_err(|e| format!("Failed to execute: {}: {}", program, e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Command {} failed : {}", program, stderr));
+        }
+
+        String::from_utf8(output.stdout)
+            .map_err(|_| "Failed to converter command. invalid UTF-8".to_string())
     }
+}
+
+pub fn execute_niri_command_with_executor<E: CommandExecutor>(
+    executor: &E,
+    args: &[&str],
+) -> Result<String, String> {
+    executor.execute("niri", args)
+}
+
+pub fn niri_execute_command(args: &[&str]) -> Result<String, String> {
+    execute_niri_command_with_executor(&SystemCommandExecutor, args)
+}
+pub fn execute_niri_help() -> Result<String, String> {
+    niri_execute_command(&["msg", "--help"])
+}
+
+pub fn get_outputs() -> Result<String, String> {
+    niri_execute_command(&["msg", "outputs"])
+}
+
+pub fn get_workspaces() -> Result<String, String> {
+    niri_execute_command(&["msg", "workspaces"])
+}
+
+pub fn get_version() -> Result<String, String> {
+    niri_execute_command(&["msg", "version"])
 }

--- a/niri-ipc/tests/integration_tests.rs
+++ b/niri-ipc/tests/integration_tests.rs
@@ -1,0 +1,75 @@
+use niri_ipc::*;
+
+use std::collections::HashMap;
+
+// Mock para testes
+pub struct MockCommandExecutor {
+    responses: HashMap<(String, Vec<String>), Result<String, String>>,
+}
+
+impl MockCommandExecutor {
+    pub fn new() -> Self {
+        Self {
+            responses: HashMap::new(),
+        }
+    }
+
+    // Configura resposta para um comando específico
+    pub fn expect_command(
+        &mut self,
+        program: &str,
+        args: &[&str],
+        response: Result<String, String>,
+    ) {
+        let key = (
+            program.to_string(),
+            args.iter().map(|s| s.to_string()).collect(),
+        );
+        self.responses.insert(key, response);
+    }
+}
+
+impl CommandExecutor for MockCommandExecutor {
+    fn execute(&self, program: &str, args: &[&str]) -> Result<String, String> {
+        let key = (
+            program.to_string(),
+            args.iter().map(|s| s.to_string()).collect(),
+        );
+
+        self.responses
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| Err(format!("Comando não mockado: {} {:?}", program, args)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_execute_niri_command_success() {
+        let mut mock = MockCommandExecutor::new();
+        mock.expect_command("niri", &["msg", "--help"], Ok("Help text".to_string()));
+
+        let result = execute_niri_command_with_executor(&mock, &["msg", "--help"]);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Help text");
+    }
+
+    #[test]
+    fn test_execute_niri_command_failure() {
+        let mut mock = MockCommandExecutor::new();
+        mock.expect_command(
+            "niri",
+            &["msg", "invalid"],
+            Err("Command failed".to_string()),
+        );
+
+        let result = execute_niri_command_with_executor(&mock, &["msg", "invalid"]);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Command failed");
+    }
+}


### PR DESCRIPTION
Implemented `niri-ipc` module with command execution interface, added mock executor for testing, and updated README completion status.